### PR TITLE
return empty array if response was an string like 404 Not found

### DIFF
--- a/lib/gusto_wrapper/http_client.rb
+++ b/lib/gusto_wrapper/http_client.rb
@@ -69,7 +69,7 @@ module GustoWrapper
 		
 		def get(path, options = false)
 			response = with_error_handling { RestClient.get(full_url(path), get_params(options)) }
-			JSON.parse(response)
+			JSON.parse(response) rescue []
 		end
 		
 		def put(path, payload)


### PR DESCRIPTION
* Added rescue to JSON.parse(response)
* return empty array if JSON.parse(response) throws an error